### PR TITLE
Dasha/publishers crud

### DIFF
--- a/src/KSE.GameStore.ApplicationCore/Models/PublisherDTO.cs
+++ b/src/KSE.GameStore.ApplicationCore/Models/PublisherDTO.cs
@@ -6,4 +6,4 @@ public class PublisherDTO
     public string Name { get; set; } = string.Empty;
     public string? WebsiteUrl { get; set; }
     public string? Description { get; set; }
-};
+}

--- a/src/KSE.GameStore.ApplicationCore/Services/IPublisherService.cs
+++ b/src/KSE.GameStore.ApplicationCore/Services/IPublisherService.cs
@@ -1,0 +1,90 @@
+﻿using KSE.GameStore.ApplicationCore.Models;
+
+namespace KSE.GameStore.ApplicationCore.Services;
+
+public interface IPublisherService
+{
+    /// <summary>
+    /// Retrieves a paginated list of all publishers.
+    /// </summary>
+    /// <param name="pageNumber">
+    /// The 1-based page number to retrieve. If null, defaults to 1.
+    /// </param>
+    /// <param name="pageSize">
+    /// The number of items per page. If null, defaults to 10.
+    /// </param>
+    /// <returns>
+    /// A list of <see cref="PublisherDTO"/> representing the requested page of publishers.
+    /// </returns>
+    /// <exception cref="BadRequestException">
+    /// Thrown when either parameter is less than or equal to zero.
+    /// </exception>
+    Task<List<PublisherDTO>> GetAllPublishersAsync(int? pageNumber, int? pageSize);
+    
+    /// <summary>
+    /// Retrieves a publisher by its unique identifier with all related entities.
+    /// </summary>
+    /// <param name="id">The unique identifier of the publisher.</param>
+    /// <returns>
+    /// The complete <see cref="PublisherDTO"/> with the specified ID including name,
+    /// website url, and description.
+    /// </returns>
+    /// <exception cref="BadRequestException">
+    /// Thrown when id is less than or equal to zero.
+    /// </exception>
+    /// <exception cref="NotFoundException">
+    /// Thrown when no publisher exists with the specified id.
+    /// </exception>
+    Task<PublisherDTO> GetPublisherByIdAsync(int id);
+    
+    /// <summary>
+    /// Creates a new publisher.
+    /// </summary>
+    /// <param name="publisherDto">
+    /// The <see cref="PublisherDTO"/> containing the publisher details.
+    /// </param>
+    /// <returns>
+    /// The newly created <see cref="PublisherDTO"/>.
+    /// </returns>
+    /// <exception cref="BadRequestException">
+    /// Thrown when:
+    /// - A publisher with the same title already exists
+    /// - Required fields are missing or invalid
+    /// </exception>
+    Task<PublisherDTO> CreatePublisherAsync(PublisherDTO publisherDto);
+    
+    /// <summary>
+    /// Updates an existing publisher.
+    /// </summary>
+    /// <param name="publisherDto">
+    /// The <see cref="PublisherDTO"/> containing updated publisher details.
+    /// </param>
+    /// <returns>
+    /// The updated <see cref="PublisherDTO"/>.
+    /// </returns>
+    /// <exception cref="BadRequestException">
+    /// Thrown when:
+    /// - The new title conflicts with another publisher
+    /// - Required fields are missing or invalid
+    /// </exception>
+    /// <exception cref="NotFoundException">
+    /// Thrown when:
+    /// - The publisher to update doesn't exist
+    /// </exception>
+    Task<PublisherDTO> UpdatePublisherAsync(PublisherDTO publisherDto);
+    
+    /// <summary>
+    /// Deletes a publisher by its unique identifier.
+    /// </summary>
+    /// <param name="id">The unique identifier of the publisher to delete.</param>
+    /// <returns>
+    /// A task representing the asynchronous delete operation.
+    /// </returns>
+    /// <exception cref="BadRequestException">
+    /// Thrown when id is less than or equal to zero.
+    /// </exception>
+    /// <exception cref="NotFoundException">
+    /// Thrown when no publisher exists with the specified id.
+    /// </exception>
+    Task DeletePublisherAsync(int id);
+}

--- a/src/KSE.GameStore.ApplicationCore/Services/PublisherService.cs
+++ b/src/KSE.GameStore.ApplicationCore/Services/PublisherService.cs
@@ -52,7 +52,7 @@ public class PublisherService : IPublisherService
     public async Task<PublisherDTO> CreatePublisherAsync(PublisherDTO publisherDto)
     {
         var existing = await _publisherRepository
-            .ListAsync(g => g.Name.ToLower() == publisherDto.Name.ToLower());
+            .ListAllAsync(g => g.Name.ToLower() == publisherDto.Name.ToLower());
 
         if (existing.Any())
             throw new BadRequestException($"A publisher with the name '{publisherDto.Name}' already exists.");
@@ -82,7 +82,7 @@ public class PublisherService : IPublisherService
         
         // Check whether new name already exists
         var existing = await _publisherRepository
-            .ListAsync(g => g.Name.ToLower() == publisherDto.Name.ToLower());
+            .ListAllAsync(g => g.Name.ToLower() == publisherDto.Name.ToLower());
 
         if (existing.Any())
             throw new BadRequestException($"A publisher with the name '{publisherDto.Name}' already exists.");

--- a/src/KSE.GameStore.ApplicationCore/Services/PublisherService.cs
+++ b/src/KSE.GameStore.ApplicationCore/Services/PublisherService.cs
@@ -1,0 +1,124 @@
+﻿using AutoMapper;
+using KSE.GameStore.ApplicationCore.Infrastructure;
+using KSE.GameStore.ApplicationCore.Models;
+using KSE.GameStore.DataAccess.Entities;
+using KSE.GameStore.DataAccess.Repositories;
+using Microsoft.Extensions.Logging;
+
+namespace KSE.GameStore.ApplicationCore.Services;
+
+public class PublisherService : IPublisherService
+{
+    private readonly IRepository<Publisher, int> _publisherRepository;
+    private readonly ILogger<PublisherService> _logger;
+    private readonly IMapper _mapper;    
+
+    public PublisherService(IRepository<Publisher, 
+        int> publisherRepository, 
+        ILogger<PublisherService> logger, 
+        IMapper mapper)
+    {
+        _publisherRepository = publisherRepository;
+        _logger = logger;
+        _mapper = mapper;
+    }
+
+    public async Task<List<PublisherDTO>> GetAllPublishersAsync(int? pageNumber, int? pageSize)
+    {
+        if (pageNumber is <= 0)
+            throw new BadRequestException($"Page number must be a positive integer. Provided: {pageNumber}");
+
+        if (pageSize is <= 0)
+            throw new BadRequestException($"Page size must be a positive integer. Provided: {pageSize}");
+
+        var publisherEntities = await _publisherRepository.ListAsync(pageNumber ?? 1, pageSize ?? 10);
+
+        return _mapper.Map<List<PublisherDTO>>(publisherEntities);
+    }
+
+    public async Task<PublisherDTO> GetPublisherByIdAsync(int id)
+    {
+        var publisherEntity = await _publisherRepository.GetByIdAsync(id);
+
+        if (publisherEntity == null)
+        {
+            _logger.LogNotFound($"publisher/{id}");
+            throw new NotFoundException($"Publisher with ID {id} not found.");
+        }
+
+        return _mapper.Map<PublisherDTO>(publisherEntity);
+    }
+
+    public async Task<PublisherDTO> CreatePublisherAsync(PublisherDTO publisherDto)
+    {
+        var existing = await _publisherRepository
+            .ListAsync(g => g.Name.ToLower() == publisherDto.Name.ToLower());
+
+        if (existing.Any())
+            throw new BadRequestException($"A publisher with the name '{publisherDto.Name}' already exists.");
+
+        var publisher = new Publisher
+        {
+            Name = publisherDto.Name,
+            WebsiteUrl = publisherDto.WebsiteUrl,
+            Description = publisherDto.Description
+        };
+
+        await _publisherRepository.AddAsync(publisher);
+        await _publisherRepository.SaveChangesAsync();
+
+        return publisherDto;
+    }
+
+    public async Task<PublisherDTO> UpdatePublisherAsync(PublisherDTO publisherDto)
+    {
+        var publisherEntity = await _publisherRepository.GetByIdAsync(publisherDto.Id);
+
+        if (publisherEntity == null)
+        {
+            _logger.LogNotFound($"publisher/{publisherDto.Id}");
+            throw new NotFoundException($"Publisher with ID {publisherDto.Id} not found.");
+        }
+        
+        var nameTaken = (await _publisherRepository
+                .ListAsync(p => p.Id != publisherDto.Id &&
+                                p.Name.Equals(publisherDto.Name, StringComparison.OrdinalIgnoreCase)))
+                .Any();
+        
+        if (nameTaken)
+            throw new BadRequestException($"Publisher '{publisherDto.Name}' already exists.");
+        
+        publisherEntity.Name = publisherDto.Name;
+
+        // If description is null, it means that user don't want to change it
+        if (publisherDto.Description != null)
+        {
+            publisherEntity.Description = publisherDto.Description;
+        }
+
+        // If website url is null, it means that user don't want to change it
+        if (publisherDto.WebsiteUrl != null)
+        {
+            publisherEntity.WebsiteUrl = publisherDto.WebsiteUrl;
+        }
+        
+        _publisherRepository.Update(publisherEntity);
+        await _publisherRepository.SaveChangesAsync();
+
+        return _mapper.Map<PublisherDTO>(_publisherRepository.GetByIdAsync(publisherDto.Id));
+    }
+
+    public async Task DeletePublisherAsync(int id)
+    {
+        var publisherEntity = await _publisherRepository.GetByIdAsync(id);
+
+        if (publisherEntity == null)
+        {
+            _logger.LogNotFound($"publisher/{id}");
+            throw new NotFoundException($"Publisher with ID {id} not found.");
+        }
+        
+        _publisherRepository.Delete(publisherEntity);
+        await _publisherRepository.SaveChangesAsync();
+    }
+}

--- a/src/KSE.GameStore.DataAccess/Repositories/IRepository.cs
+++ b/src/KSE.GameStore.DataAccess/Repositories/IRepository.cs
@@ -14,6 +14,7 @@ public interface IRepository<T, TKey> where T : BaseEntity<TKey>
 
     /// <summary>
     /// Lists entities with optional pagination.
+    /// </summary>
     /// <param name="pageNumber">The page number to retrieve.</param>
     /// <param name="pageSize">The number of entities per page.</param>
     /// <returns>A task that represents the asynchronous operation. The task contains a collection of entities.</returns>

--- a/src/KSE.GameStore.Web/Controllers/PublishersController.cs
+++ b/src/KSE.GameStore.Web/Controllers/PublishersController.cs
@@ -1,0 +1,58 @@
+﻿using AutoMapper;
+using KSE.GameStore.ApplicationCore.Models;
+using KSE.GameStore.ApplicationCore.Services;
+using KSE.GameStore.Web.Requests.Publishers;
+using Microsoft.AspNetCore.Mvc;
+
+namespace KSE.GameStore.Web.Controllers;
+
+[ApiController]
+[Route("[controller]")]
+public class PublishersController : ControllerBase
+{
+    private readonly IPublisherService _publisherService;
+    private readonly IMapper _mapper; 
+
+    public PublishersController(IPublisherService publisherService, IMapper mapper)
+    {
+        _publisherService = publisherService;
+        _mapper = mapper;
+    }
+    
+    [HttpGet]
+    public async Task<IActionResult> GetAllPublishers(int? pageNumber, int? pageSize)
+    {
+        var publisherDto = await _publisherService.GetAllPublishersAsync(pageNumber, pageSize);
+        return Ok(publisherDto);
+    }
+    
+    [HttpGet("{id:int}")]
+    public async Task<IActionResult> GetPublisherById([FromRoute] int id)
+    {
+        var publisherDto = await _publisherService.GetPublisherByIdAsync(id);
+        return Ok(publisherDto);
+    }
+    
+    [HttpPost]
+    public async Task<IActionResult> CreatePublisher([FromBody] CreatePublisherRequest createPublisherRequest)
+    {
+        var publisherDto = _mapper.Map<CreatePublisherRequest, PublisherDTO>(createPublisherRequest);
+        var createdPublisherDto = await _publisherService.CreatePublisherAsync(publisherDto);
+        return Ok(createdPublisherDto);
+    }
+
+    [HttpPut]
+    public async Task<IActionResult> UpdatePublisher([FromBody] UpdatePublisherRequest updatePublisherRequest)
+    {
+        var publisherDto = _mapper.Map<UpdatePublisherRequest, PublisherDTO>(updatePublisherRequest);
+        var updatedPublisherDto = await _publisherService.UpdatePublisherAsync(publisherDto);
+        return Ok(updatedPublisherDto);
+    }
+
+    [HttpDelete("{id:int}")]
+    public async Task<IActionResult> DeletePublisher(int id)
+    {
+        await _publisherService.DeletePublisherAsync(id);
+        return NoContent();
+    }
+}

--- a/src/KSE.GameStore.Web/Mapping/WebMappingProfile.cs
+++ b/src/KSE.GameStore.Web/Mapping/WebMappingProfile.cs
@@ -1,6 +1,7 @@
 using KSE.GameStore.ApplicationCore.Models;
 using KSE.GameStore.Web.Requests.Games;
 using AutoMapper;
+using KSE.GameStore.Web.Requests.Publishers;
 using KSE.GameStore.Web.Responses;
 
 namespace KSE.GameStore.Web.Mapping;
@@ -29,6 +30,10 @@ public class WebMappingProfile : Profile
         CreateMap<CreateGamePriceRequest, GamePriceDTO>()
             .ForMember(dest => dest.Id, opt => opt.Ignore());
 
+        // CreatePublisherRequest → PublisherDTO
+        CreateMap<CreatePublisherRequest, PublisherDTO>()
+            .ForMember(dest => dest.Id, opt => opt.Ignore());
+        
         // UpdateGameRequest → GameDTO
         CreateMap<UpdateGameRequest, GameDTO>()
             .ForMember(dest => dest.Publisher, opt => opt.MapFrom(src => new PublisherDTO { Id = src.PublisherId }))
@@ -45,5 +50,8 @@ public class WebMappingProfile : Profile
         // UpdateGamePriceRequest → GamePriceDTO
         CreateMap<UpdateGamePriceRequest, GamePriceDTO>()
             .ForMember(dest => dest.Id, opt => opt.Ignore());
+        
+        // UpdatePublisherRequest → PublisherDTO
+        CreateMap<UpdatePublisherRequest, PublisherDTO>();
     }
 }

--- a/src/KSE.GameStore.Web/Program.cs
+++ b/src/KSE.GameStore.Web/Program.cs
@@ -8,11 +8,16 @@ using Microsoft.EntityFrameworkCore;
 
 var builder = WebApplication.CreateBuilder(args);
 
-// Add services to the container.
+// ---------------------------------------------
+// Logging
+// ---------------------------------------------
 builder.Logging.ClearProviders();
 builder.Logging.AddConsole();
 builder.Logging.AddDebug();
 
+// ---------------------------------------------
+// Core services
+// ---------------------------------------------
 builder.Services.AddRouting(options => options.LowercaseUrls = true);
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
@@ -25,26 +30,27 @@ if (!builder.Environment.IsEnvironment("IntegrationTest"))
             x => x.MigrationsAssembly("KSE.GameStore.Migrations")));
 }
 
+// Repositories
 builder.Services.AddScoped<IGameRepository, GameRepository>();
 builder.Services.AddScoped(typeof(IRepository<,>), typeof(Repository<,>));
+
+// Domain services
 builder.Services.AddScoped<IPlatformsService, PlatformsService>();
-builder.Services.AddControllers();
-
 builder.Services.AddScoped<IGenreService, GenreService>();
+builder.Services.AddScoped<IGameService, GameService>();
+builder.Services.AddScoped<IPublisherService, PublisherService>();
 
-builder.Services.AddControllers();
-
+// AutoMapper
 builder.Services.AddAutoMapper(cfg => { cfg.AllowNullCollections = true; },
     typeof(ApplicationCoreMappingProfile),
     typeof(WebMappingProfile));
 
-builder.Services.AddScoped<IGameService, GameService>();
-
-builder.Services
-    .AddRouting(options => { options.LowercaseUrls = true; });
-
+// MVC controllers
 builder.Services.AddControllers();
 
+// ---------------------------------------------
+// Build pipeline
+// ---------------------------------------------
 var app = builder.Build();
 
 app.MapControllers();

--- a/src/KSE.GameStore.Web/Requests/Publishers/CreatePublisherRequest.cs
+++ b/src/KSE.GameStore.Web/Requests/Publishers/CreatePublisherRequest.cs
@@ -1,0 +1,3 @@
+﻿namespace KSE.GameStore.Web.Requests.Publishers;
+
+public record CreatePublisherRequest(string Name, string? Description, string? WebsiteUrl);

--- a/src/KSE.GameStore.Web/Requests/Publishers/UpdatePublisherRequest.cs
+++ b/src/KSE.GameStore.Web/Requests/Publishers/UpdatePublisherRequest.cs
@@ -1,0 +1,8 @@
+﻿namespace KSE.GameStore.Web.Requests.Publishers;
+
+public record UpdatePublisherRequest(
+    int Id, 
+    string Name, 
+    string WebsiteUrl, 
+    string Description
+);

--- a/tests/KSE.GameStore.Tests/IntegrationTests/Controllers/PublisherControllerTests.cs
+++ b/tests/KSE.GameStore.Tests/IntegrationTests/Controllers/PublisherControllerTests.cs
@@ -1,0 +1,150 @@
+﻿using System.Net;
+using System.Net.Http.Json;
+using KSE.GameStore.ApplicationCore.Mapping;
+using KSE.GameStore.ApplicationCore.Models;
+using KSE.GameStore.DataAccess;
+using KSE.GameStore.Web.Mapping;
+using KSE.GameStore.Web.Requests.Publishers;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace KSE.GameStore.Tests.IntegrationTests.Controllers;
+
+public class PublisherControllerTests : IClassFixture<WebApplicationFactory<Program>>
+{
+    private readonly WebApplicationFactory<Program> _factory;
+
+    public PublisherControllerTests(WebApplicationFactory<Program> factory)
+    {
+        var dbName = $"PublisherTestDb-{Guid.NewGuid()}";
+        _factory = factory.WithWebHostBuilder(builder =>
+        {
+            builder.UseEnvironment("IntegrationTest");
+            builder.ConfigureServices(services =>
+            {
+                // Remove existing DbContext configuration
+                var dbContext = services.SingleOrDefault(
+                    d => d.ServiceType == typeof(DbContextOptions<GameStoreDbContext>));
+                if (dbContext != null)
+                    services.Remove(dbContext);
+
+                // Add in-memory database
+                services.AddDbContext<GameStoreDbContext>(options => { options.UseInMemoryDatabase(dbName); });
+
+                services.AddAutoMapper(typeof(ApplicationCoreMappingProfile), typeof(WebMappingProfile));
+            });
+        });
+    }
+    
+    [Fact]
+    public async Task GetAllPublishers_ReturnsOkAndEmptyListInitially()
+    {
+        // Act
+        var client = _factory.CreateClient();
+        var response = await client.GetAsync("/publishers");
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var result = await response.Content.ReadFromJsonAsync<List<PublisherDTO>>();
+        Assert.NotNull(result);
+        Assert.Empty(result!);
+    }
+    
+    [Fact]
+    public async Task CreatePublisher_ReturnsOkAndCreatedPublisher()
+    {
+        // Arrange
+        var client = _factory.CreateClient();
+        var request = new CreatePublisherRequest("TestPub", "Test publisher", "https://test.com");
+
+
+        // Act
+        var response = await client.PostAsJsonAsync("/publishers", request);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var result = await response.Content.ReadFromJsonAsync<PublisherDTO>();
+        Assert.NotNull(result);
+        Assert.Equal(request.Name, result!.Name);
+        Assert.Equal(request.WebsiteUrl, result.WebsiteUrl);
+        Assert.Equal(request.Description, result.Description);
+    }
+    
+    [Fact]
+    public async Task GetPublisherById_ReturnsOk_WhenExists()
+    {
+        // Arrange
+        var client = _factory.CreateClient();
+        var create = new CreatePublisherRequest("LookupPub", "desc", "https://lookup.com");
+
+        var postResponse = await client.PostAsJsonAsync("/publishers", create);
+        var created = await postResponse.Content.ReadFromJsonAsync<PublisherDTO>();
+
+        // Act
+        var getResponse = await client.GetAsync($"/publishers/{created!.Id}");
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, getResponse.StatusCode);
+
+        var result = await getResponse.Content.ReadFromJsonAsync<PublisherDTO>();
+        Assert.Equal(created.Id, result!.Id);
+        Assert.Equal("LookupPub", result.Name);
+        Assert.Equal("https://lookup.com", result.WebsiteUrl);
+        Assert.Equal("desc", result.Description);
+    }
+    
+    [Fact]
+    public async Task DeletePublisher_ReturnsNoContent_WhenExists()
+    {
+        // Arrange
+        var client = _factory.CreateClient();
+        var request = new CreatePublisherRequest("ToDelete", "desc", "https://delete.com");
+
+        var createdResponse = await client.PostAsJsonAsync("/publishers", request);
+        var created = await createdResponse.Content.ReadFromJsonAsync<PublisherDTO>();
+
+        // Act
+        var deleteResponse = await client.DeleteAsync($"/publishers/{created!.Id}");
+
+        // Assert
+        Assert.Equal(HttpStatusCode.NoContent, deleteResponse.StatusCode);
+    }
+    
+    [Fact]
+    public async Task UpdatePublisher_ReturnsOk_WhenValid()
+    {
+        // Arrange
+        var client = _factory.CreateClient();
+        var createRequest = new CreatePublisherRequest(
+            "Updatable",
+            "before",
+            "https://before.com"
+        );
+
+
+        var createResponse = await client.PostAsJsonAsync("/publishers", createRequest);
+        var created = await createResponse.Content.ReadFromJsonAsync<PublisherDTO>();
+
+        var updateRequest = new UpdatePublisherRequest(
+            created!.Id, 
+            "UpdatedName",
+            "https://after.com",
+            "after update"
+        );
+
+        // Act
+        var updateResponse = await client.PutAsJsonAsync("/publishers", updateRequest);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, updateResponse.StatusCode);
+        var updated = await updateResponse.Content.ReadFromJsonAsync<PublisherDTO>();
+
+        Assert.Equal("UpdatedName", updated!.Name);
+        Assert.Equal("https://after.com", updated.WebsiteUrl);
+        Assert.Equal("after update", updated.Description);
+    }
+}

--- a/tests/KSE.GameStore.Tests/UnitTests/Services/PublisherServiceTests.cs
+++ b/tests/KSE.GameStore.Tests/UnitTests/Services/PublisherServiceTests.cs
@@ -1,0 +1,297 @@
+﻿using System.Linq.Expressions;
+using AutoMapper;
+using KSE.GameStore.ApplicationCore.Mapping;
+using KSE.GameStore.ApplicationCore.Models;
+using KSE.GameStore.ApplicationCore.Services;
+using KSE.GameStore.DataAccess.Entities;
+using KSE.GameStore.DataAccess.Repositories;
+using KSE.GameStore.Web.Mapping;
+using Microsoft.Extensions.Logging;
+using Moq;
+
+namespace KSE.GameStore.Tests.UnitTests.Services;
+
+public class PublisherServiceTests
+{
+    private readonly Mock<IRepository<Publisher, int>> _mockRepo;
+    private readonly Mock<ILogger<PublisherService>> _mockLogger;
+    private readonly IMapper _mapper;
+    private readonly PublisherService _service;
+
+    #region Constructor
+    
+    public PublisherServiceTests()
+    {
+        _mockRepo = new Mock<IRepository<Publisher, int>>();
+        _mockLogger = new Mock<ILogger<PublisherService>>();
+        
+        var config = new MapperConfiguration(cfg =>
+        {
+            cfg.AllowNullCollections = true;
+            cfg.AddProfile<WebMappingProfile>();
+            cfg.AddProfile<ApplicationCoreMappingProfile>();
+        });
+        _mapper = config.CreateMapper();
+        
+        _service = new PublisherService(
+            _mockRepo.Object, 
+            _mockLogger.Object, 
+            _mapper);
+    }
+    
+    #endregion
+
+    #region GetAll Tests
+
+    public class GetAllPublishers : PublisherServiceTests
+    {
+        [Fact]
+        public async Task GetAllPublishersAsync_ReturnsMappedList()
+        {
+            // Arrange
+            var publishers = new List<Publisher>
+            {
+                new() { Id = 1, Name = "P1", WebsiteUrl = "url1", Description = "desc1" },
+                new() { Id = 2, Name = "P2", WebsiteUrl = "url2", Description = "desc2" },
+            };
+
+            _mockRepo.Setup(r => r.ListAsync(1, 10)).ReturnsAsync(publishers);
+
+            // Act
+            var result = await _service.GetAllPublishersAsync(1, 10);
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.Equal(2, result.Count);
+            Assert.Equal("P1", result[0].Name);
+            Assert.Equal("P2", result[1].Name);
+        }
+
+        [Fact]
+        public async Task GetAllPublishersAsync_ThrowsBadRequest_WhenPageNumberIsZero()
+        {
+            // Act & Assert
+            var ex = await Assert.ThrowsAsync<BadRequestException>(() => _service.GetAllPublishersAsync(0, 10));
+            Assert.Contains("Page number", ex.Message);
+        }
+
+        [Fact]
+        public async Task GetAllPublishersAsync_ThrowsBadRequest_WhenPageSizeIsZero()
+        {
+            // Act & Assert
+            var ex = await Assert.ThrowsAsync<BadRequestException>(() => _service.GetAllPublishersAsync(1, 0));
+            Assert.Contains("Page size", ex.Message);
+        }
+
+        [Fact]
+        public async Task GetAllPublishersAsync_UsesDefaultPaging_WhenNullsProvided()
+        {
+            // Arrange
+            var publishers = new List<Publisher> { new() { Id = 1, Name = "Default" } };
+
+            _mockRepo.Setup(r => r.ListAsync(1, 10)).ReturnsAsync(publishers);
+
+            // Act
+            var result = await _service.GetAllPublishersAsync(null, null);
+
+            // Assert
+            Assert.Single(result);
+            Assert.Equal("Default", result.First().Name);
+        }
+    }
+
+    #endregion
+    
+    #region GetById Tests
+    
+    public class GetPublisherById : PublisherServiceTests
+    {
+        [Fact]
+        public async Task GetPublisherByIdAsync_ThrowsNotFound_WhenPublisherMissing()
+        {
+            // Act
+            _mockRepo.Setup(r => r.GetByIdAsync(1)).ReturnsAsync((Publisher)null!);
+
+            // Act & Assert
+            await Assert.ThrowsAsync<NotFoundException>(() => _service.GetPublisherByIdAsync(1));
+        }
+        
+        [Fact]
+        public async Task GetPublisherByIdAsync_ReturnsPublisher_WhenExists()
+        {
+            // Arrange
+            var publisher = new Publisher
+            {
+                Id = 1,
+                Name = "Test Publisher",
+                WebsiteUrl = "http://example.com",
+                Description = "Sample description"
+            };
+
+            _mockRepo.Setup(r => r.GetByIdAsync(1)).ReturnsAsync(publisher);
+
+            // Act
+            var result = await _service.GetPublisherByIdAsync(1);
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.Equal(publisher.Id, result.Id);
+            Assert.Equal(publisher.Name, result.Name);
+            Assert.Equal(publisher.WebsiteUrl, result.WebsiteUrl);
+            Assert.Equal(publisher.Description, result.Description);
+        }
+    }
+    
+    #endregion
+
+    #region Create Tests
+    
+    public class CreatePublisher : PublisherServiceTests
+    {
+        [Fact]
+        public async Task CreatePublisherAsync_ThrowsBadRequest_WhenDuplicateName()
+        {
+            // Arrange
+            var dto = new PublisherDTO
+            {
+                Name = "Test Game",
+                WebsiteUrl = "https://new.com",
+                Description = "desc"
+            };
+
+            var existingPublishers = new List<Publisher> { new() { Name = "Test Game" } };
+
+            _mockRepo.Setup(r => r.ListAllAsync(It.IsAny<Expression<Func<Publisher, bool>>>()))
+                .ReturnsAsync(existingPublishers);
+
+            // Act & Assert
+            await Assert.ThrowsAsync<BadRequestException>(() => _service.CreatePublisherAsync(dto));
+        }
+        
+        [Fact]
+        public async Task CreatePublisherAsync_CreatesPublisherSuccessfully()
+        {
+            // Arrange
+            var dto = new PublisherDTO
+            {
+                Name = "New Publisher",
+                WebsiteUrl = "https://new.com",
+                Description = "new desc"
+            };
+
+            _mockRepo.Setup(r => r.ListAllAsync(It.IsAny<Expression<Func<Publisher, bool>>>()))
+                .ReturnsAsync(new List<Publisher>());
+
+            Publisher? addedPublisher = null;
+            _mockRepo.Setup(r => r.AddAsync(It.IsAny<Publisher>()))
+                .Callback<Publisher>(pub => addedPublisher = pub)
+                .Returns(Task.CompletedTask);
+
+            _mockRepo.Setup(r => r.SaveChangesAsync()).Returns(Task.CompletedTask);
+
+            // Act
+            var result = await _service.CreatePublisherAsync(dto);
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.Equal(dto.Name, addedPublisher?.Name);
+            Assert.Equal(dto.Description, addedPublisher?.Description);
+            Assert.Equal(dto.WebsiteUrl, addedPublisher?.WebsiteUrl);
+        }
+    }
+    
+    #endregion
+
+    #region Update Tests
+    
+    public class UpdatePublisher : PublisherServiceTests
+    {
+        [Fact]
+        public async Task UpdatePublisherAsync_ThrowsNotFound_WhenPublisherMissing()
+        {
+            // Arrange
+            var dto = new PublisherDTO { Id = 1, Name = "Updated", Description = "desc", WebsiteUrl = "url" };
+
+            _mockRepo.Setup(r => r.GetByIdAsync(dto.Id)).ReturnsAsync((Publisher)null!);
+
+            // Act & Assert
+            await Assert.ThrowsAsync<NotFoundException>(() => _service.UpdatePublisherAsync(dto));
+        }
+        
+        [Fact]
+        public async Task UpdatePublisherAsync_ThrowsBadRequest_WhenNameAlreadyExists()
+        {
+            // Arrange
+            var dto = new PublisherDTO { Id = 1, Name = "Updated Name", Description = "desc", WebsiteUrl = "url" };
+            var existingPublisher = new Publisher { Id = 1, Name = "Old Name", Description = "desc", WebsiteUrl = "url" };
+
+            _mockRepo.Setup(r => r.GetByIdAsync(dto.Id)).ReturnsAsync(existingPublisher);
+            _mockRepo.Setup(r => r.ListAllAsync(It.IsAny<Expression<Func<Publisher, bool>>>()))
+                .ReturnsAsync(new List<Publisher> { new() { Id = 2, Name = "Updated Name" } });
+
+            // Act & Assert
+            await Assert.ThrowsAsync<BadRequestException>(() => _service.UpdatePublisherAsync(dto));
+        }
+        
+        [Fact]
+        public async Task UpdatePublisherAsync_UpdatesSuccessfully()
+        {
+            // Arrange
+            var dto = new PublisherDTO { Id = 1, Name = "Updated Name", Description = "new desc", WebsiteUrl = "new url" };
+            var existingPublisher = new Publisher { Id = 1, Name = "Old Name", Description = "desc", WebsiteUrl = "url" };
+
+            _mockRepo.Setup(r => r.GetByIdAsync(dto.Id)).ReturnsAsync(existingPublisher);
+            _mockRepo.Setup(r => r.ListAllAsync(It.IsAny<Expression<Func<Publisher, bool>>>()))
+                .ReturnsAsync(new List<Publisher>());
+
+            _mockRepo.Setup(r => r.SaveChangesAsync()).Returns(Task.CompletedTask);
+            _mockRepo.Setup(r => r.Update(It.IsAny<Publisher>()));
+            _mockRepo.Setup(r => r.GetByIdAsync(dto.Id)).ReturnsAsync(existingPublisher);
+
+            // Act
+            var result = await _service.UpdatePublisherAsync(dto);
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.Equal(dto.Name, result.Name);
+            Assert.Equal(dto.Description, result.Description);
+            Assert.Equal(dto.WebsiteUrl, result.WebsiteUrl);
+        }
+    }
+    
+    #endregion
+
+    #region Delete Tests
+
+    public class DeletePublisher : PublisherServiceTests
+    {
+        [Fact]
+        public async Task DeletePublisherAsync_ThrowsNotFound_WhenPublisherMissing()
+        {
+            // Arrange
+            _mockRepo.Setup(r => r.GetByIdAsync(1)).ReturnsAsync((Publisher)null!);
+
+            // Act & Assert
+            await Assert.ThrowsAsync<NotFoundException>(() => _service.DeletePublisherAsync(1));
+        }
+
+        [Fact]
+        public async Task DeletePublisherAsync_DeletesSuccessfully()
+        {
+            // Arrange
+            var publisher = new Publisher { Id = 1, Name = "ToDelete" };
+
+            _mockRepo.Setup(r => r.GetByIdAsync(1)).ReturnsAsync(publisher);
+            _mockRepo.Setup(r => r.SaveChangesAsync()).Returns(Task.CompletedTask);
+
+            // Act
+            await _service.DeletePublisherAsync(1);
+
+            // Assert
+            _mockRepo.Verify(r => r.Delete(publisher), Times.Once);
+            _mockRepo.Verify(r => r.SaveChangesAsync(), Times.Once);
+        }
+    }
+
+    #endregion
+}


### PR DESCRIPTION
### Business Logic Layer
- Added `IPublisherService` interface and `PublisherService` implementation
- Supports CRUD operations with:
  - Validation
  - Logging
  - AutoMapper-based transformation

### API Layer
- Implemented `PublishersController` with endpoints:
  - `GET /publishers`
  - `GET /publishers/{id}`
  - `POST /publishers`
  - `PUT /publishers`
  - `DELETE /publishers/{id}`
- Defined request models:
  - `CreatePublisherRequest`
  - `UpdatePublisherRequest`

### Mapping
- Extended AutoMapper profiles to support:
  - `CreatePublisherRequest` → `PublisherDTO`
  - `UpdatePublisherRequest` → `PublisherDTO`
  
  ---

### Tests

- ✅ Unit tests for `PublisherService`
- ✅ Integration tests for `PublishersController` using `WebApplicationFactory` and in-memory database